### PR TITLE
Changes as part of repo audit

### DIFF
--- a/toc
+++ b/toc
@@ -34,8 +34,9 @@ Managing SoftLayer resources
         cpsub2not.md
         cpprotectsys.md
         cpcompsegapptiers.md
-        cpcompmanlic.md
-        cprebootserver.md
+        [Managing servers](/vsi/virtual-servers-managing-virtual-servers)
+        [Managing control panel licenses](/infrastructure/software/software-cp_compacclisc)
+        [Managing software passwords](/infrastructure/software/software-cp_bpmanacctresp)
         cpcompmanbwpool.md
         cpcompuschrootkittool.md
     {: .navgroup-end}


### PR DESCRIPTION
Moved Managing servers file (cpcompmanlic.md) to vsi repo (https://github.ibm.com/Bluemix/compute-doc/issues/632)
Moved Control panel license and Software passwords topics to the software repo (https://github.ibm.com/Bluemix/compute-doc/issues/632)

Resulted in adding the following link to the:
        [Managing control panel licenses](/infrastructure/software/software-cp_compacclisc)
        [Managing software passwords](/infrastructure/software/software-cp_bpmanacctresp)