### PR TITLE
removes reference to a development environment.

### DIFF
--- a/cpapi.md
+++ b/cpapi.md
@@ -22,14 +22,14 @@ subcollection: customer-portal
 # SoftLayer API
 {: #customerportal_api}
 
-You can use the API to interact with your account, products, and services by using direct API calls in a development environment instead of using the customer portal.
+You can use the API to interact with your account, products, and services by using direct API calls instead of using the customer portal.
 {:shortdesc}
 
-The goal of the API is to provide an environment where you can complete any customer portal task in the API. The API environment is maintained with frequent additions and updates to ensure that you have the best options available. This includes the ability to program in various languages and options to use SOAP, XML-RPC and REST-based APIs. Similar to working in the customer portal, if you primarily make account interactions in the API, you need a viable source for support as well.
+The goal of the API is to provide a method of programatically interacting with SoftLayer. Any action that can be performed in the control portal can be performed via the API as the customer portal itself uses the SoftLayer API to perform its actions. The API is maintained with frequent additions and updates to ensure that you have the best options available. This includes the ability to program in various languages and options to use SOAP, XML-RPC and REST-based APIs. Similar to working in the customer portal, if you primarily make account interactions in the API, you need a viable source for support as well.
 
 The [SoftLayer Development Network (SLDN) ![External link icon](../icons/launch-glyph.svg)](http://sldn.softlayer.com/){:new_window} is dedicated to supporting you when interacting with your account, products, and services by using the API. The [SLDN ![External link icon](../icons/launch-glyph.svg)](http://sldn.softlayer.com/){:new_window} contains documentation on SoftLayer APIs, supported programming languages, available API calls, and more. The SLDN is the resource to use for information on various API features, a complete list of API calls, and various blog posts to give you ideas on how to best use the API.
 
-If you have any questions about the API, you can post them in the customer forums or through direct article feedback.
+If you are unsure how a specific service works, or would like an example created to solve a generic problem, feel free to open an issue on our [SLDN github ![External link icon](../icons/launch-glyph.svg)]](https://github.com/softlayer/softlayer.github.io){:new_window}. If you encounter any unexpected errors or incorrect data being returned from the API, a support ticket should be opened about the issue instead.
 
 ## Accessing the API 
 {: #cp_getapikey}


### PR DESCRIPTION
and adds a link to the https://github.com/softlayer/softlayer.github.io page.

Calling the API a "development environment" is a little problematic as it makes it seem like the API and the portal are 2 different environments, which they are not.